### PR TITLE
fix: Fixed exception when multiple validation fails with the same error code

### DIFF
--- a/src/main/java/it/pagopa/swclient/mil/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/it/pagopa/swclient/mil/ConstraintViolationExceptionMapper.java
@@ -82,7 +82,7 @@ public class ConstraintViolationExceptionMapper implements ExceptionMapper<Const
 				}
 				return new Error(errorCode, message);
 			})
-			.collect(Collectors.toMap(Error::getCode, Error::getDescription));
+			.collect(Collectors.toMap(Error::getCode, Error::getDescription, (value1, value2) -> value1));
 
 		return Response
 			.status(Response.Status.BAD_REQUEST.getStatusCode())


### PR DESCRIPTION
Fixed "java.lang.IllegalStateException: Duplicate key" when multiple validation fails with the same errorCode